### PR TITLE
feat: add agent-device flows for key Inbox Sentry spans

### DIFF
--- a/.claude/skills/agent-device/flows/open-create-expense.ad
+++ b/.claude/skills/agent-device/flows/open-create-expense.ad
@@ -1,0 +1,11 @@
+# @desc   From the Inbox tab, open the FAB actions menu and tap "Create expense". Triggers the ManualOpenCreateExpense Sentry span (startMoneyRequest -> IOURequestStart/Participants/Confirmation page). Assumes the user is signed in and the Inbox bottom nav with the floating action button is visible.
+# @pre    text="Inbox"
+# @pre    role="button" label="Open actions menu"
+# @post   role="button" label="Create expense"
+# @tag    iou
+# @tag    navigation
+# @tag    perf
+# @span   ManualOpenCreateExpense
+find "Inbox" "click"
+press "role=\"button\" label=\"Open actions menu\" || label=\"Open actions menu\""
+press "role=\"button\" label=\"Create expense\" || label=\"Create expense\""

--- a/.claude/skills/agent-device/flows/open-search-router.ad
+++ b/.claude/skills/agent-device/flows/open-search-router.ad
@@ -1,0 +1,11 @@
+# @desc   Open the SearchRouter from the Inbox tab. Triggers the ManualOpenSearchRouter Sentry span (Search button tap -> SearchRouterPage visible). Assumes the user is signed in.
+# @pre    role="button" label="Inbox"
+# @pre    role="button" label="Search"
+# @post   text="SearchRouterPage"
+# @post   role="text-field" label="Search for something"
+# @tag    navigation
+# @tag    perf
+# @tag    search
+# @span   ManualOpenSearchRouter
+press "role=\"button\" label=\"Inbox\" || label=\"Inbox\""
+press "role=\"button\" label=\"Search\" || label=\"Search\""

--- a/.claude/skills/agent-device/flows/send-message.ad
+++ b/.claude/skills/agent-device/flows/send-message.ad
@@ -1,0 +1,12 @@
+# @desc   From the Inbox tab, open the first chat in the LHN, type a message and send it. Triggers the ManualSendMessage Sentry span (Send press -> optimistic message fragment rendered). Assumes the user is signed in with at least one chat in the Inbox.
+# @pre    text="Inbox"
+# @post   role="textview" label="Write something..."
+# @param  message=Hello from agent-device ManualSendMessage flow
+# @tag    chat
+# @tag    navigation
+# @tag    perf
+# @span   ManualSendMessage
+find "Inbox" "click"
+find "Navigates to a chat" "click"
+fill "id=\"composer\" || role=\"textview\" label=\"Write something...\" editable=true || label=\"Write something...\" editable=true" "Hello from agent-device ManualSendMessage flow"
+press "role=\"button\" label=\"Send\" || label=\"Send\""

--- a/.claude/skills/agent-device/flows/switch-home-to-inbox.ad
+++ b/.claude/skills/agent-device/flows/switch-home-to-inbox.ad
@@ -1,0 +1,9 @@
+# @desc   Switch the bottom navigation tab from Home to Inbox. Triggers the ManualNavigateToInboxTab Sentry span end-to-end (BottomTab click -> Inbox layout completion). Assumes the user is signed in and the bottom nav bar is visible.
+# @pre    role="button" label="Home"
+# @pre    role="button" label="Inbox"
+# @post   text="Inbox"
+# @tag    navigation
+# @tag    perf
+# @span   ManualNavigateToInboxTab
+press "role=\"button\" label=\"Home\" || label=\"Home\""
+press "role=\"button\" label=\"Inbox\" || label=\"Inbox\""

--- a/.claude/skills/agent-device/flows/switch-home-to-reports.ad
+++ b/.claude/skills/agent-device/flows/switch-home-to-reports.ad
@@ -1,0 +1,9 @@
+# @desc   Switch the bottom navigation tab from Home to Reports. Triggers the ManualNavigateToReports Sentry span end-to-end (BottomTab click -> Reports screen layout completion). Assumes the user is signed in and the bottom nav bar is visible.
+# @pre    role="button" label="Home"
+# @pre    role="button" label="Reports"
+# @post   text="Reports"
+# @tag    navigation
+# @tag    perf
+# @span   ManualNavigateToReports
+press "role=\"button\" label=\"Home\" || label=\"Home\""
+press "role=\"button\" label=\"Reports\" || label=\"Reports\""


### PR DESCRIPTION
## Summary

- Adds six composable agent-device `.ad` flows under `.claude/skills/agent-device/flows/` that reproduce and tag the most important Inbox-level Sentry spans:
  - `switch-home-to-inbox.ad` -> `ManualNavigateToInboxTab`
  - `switch-home-to-reports.ad` -> `ManualNavigateToReports`
  - `open-search-router.ad` -> `ManualOpenSearchRouter`
  - `send-message.ad` -> `ManualSendMessage`
  - `open-create-expense.ad` -> `ManualOpenCreateExpense`
  - `leave-create-expense.ad` -> helper that returns via the header chevron
- Each flow declares `@desc`, `@pre`, `@post`, `@tag` metadata so the agent can match snapshots and chain flows automatically.
- Every span-triggering flow is tagged with `@span <SpanName>` so performance tooling can discover the reproduction path by grep.
- Updates the flows `README.md` index with the new entries.

## Test plan

- [ ] Replay each flow on iOS simulator from the matching `@pre` state.
- [ ] Verify each `@post` selector resolves after replay.
- [ ] Confirm the associated Sentry span fires (e.g. via `measure-span`).