### PR TITLE
Add Share Extension receipt telemetry: stamp trace id, log capture and submit milestones

### DIFF
--- a/src/libs/telemetry/ReceiptObservability.ts
+++ b/src/libs/telemetry/ReceiptObservability.ts
@@ -15,7 +15,7 @@ const RECEIPT_LOG_PREFIX = '[Receipt]';
 type ReceiptSnapshotTrigger = 'signOut' | 'background' | 'foreground';
 
 /** How a receipt entered the app. */
-type ReceiptCaptureSource = 'camera' | 'gallery' | 'file' | 'replace';
+type ReceiptCaptureSource = 'camera' | 'gallery' | 'file' | 'replace' | 'share';
 
 /**
  * Maps the picker capture path to a source. On native the picker is the OS gallery. On web the same callback fires

--- a/src/pages/Share/SubmitDetailsPage.tsx
+++ b/src/pages/Share/SubmitDetailsPage.tsx
@@ -31,6 +31,7 @@ import {
 import {setMoneyRequestReceipt} from '@libs/actions/IOU/Receipt';
 import {requestMoney, trackExpense} from '@libs/actions/IOU/TrackExpense';
 import type {GPSPoint as GpsPoint} from '@libs/actions/IOU/types/TrackExpenseTransactionParams';
+import {WRITE_COMMANDS} from '@libs/API/types';
 import DateUtils from '@libs/DateUtils';
 import {getFileName, readFileAsync} from '@libs/fileDownload/FileUtils';
 import getCurrentPosition from '@libs/getCurrentPosition';
@@ -46,6 +47,7 @@ import {hasOnlyPersonalPolicies as hasOnlyPersonalPoliciesUtil, isGroupPolicy} f
 import {shouldValidateFile} from '@libs/ReceiptUtils';
 import {isMoneyRequestReport, isSelfDM} from '@libs/ReportUtils';
 import {cancelSpan, endSpan} from '@libs/telemetry/activeSpans';
+import {logReceiptCaptured, logReceiptSubmitted, mintAndStampReceiptTraceId} from '@libs/telemetry/ReceiptObservability';
 import {getDefaultTaxCode, getIsFromGlobalCreate, getTaxValue} from '@libs/TransactionUtils';
 
 import DraftWorkspaceOpener from '@pages/iou/request/step/confirmation/DraftWorkspaceOpener';
@@ -258,6 +260,15 @@ function SubmitDetailsPage({
         // `transaction.transactionID` is the draft placeholder; mirror the action's `existingTransactionID ?? rand64()` chain so cleanup nav targets the created expense.
         const optimisticTransactionID = existingTransactionID ?? rand64();
 
+        // This path skips createTransaction, so log the submit milestone here to map the draft id to the final one.
+        logReceiptSubmitted({
+            receiptTraceId: receipt.receiptTraceId,
+            draftTransactionID: transaction.transactionID,
+            transactionID: optimisticTransactionID,
+            command: isSelfDM(report) ? WRITE_COMMANDS.TRACK_EXPENSE : WRITE_COMMANDS.REQUEST_MONEY,
+            iouType,
+        });
+
         if (isSelfDM(report)) {
             trackExpense({
                 report: report ?? {reportID: reportOrAccountID},
@@ -361,6 +372,10 @@ function SubmitDetailsPage({
     const onSuccess = (file: File, locationPermissionGranted?: boolean) => {
         const receipt: Receipt = file;
         receipt.state = file && CONST.IOU.RECEIPT_STATE.SCAN_READY;
+        // The share flow builds the receipt here by hand and skips buildReceiptFiles, so this is the only place to stamp
+        // the trace id and log the capture.
+        const receiptTraceId = mintAndStampReceiptTraceId(receipt);
+        logReceiptCaptured({file: receipt, captureSource: 'share', receiptTraceId});
         if (!locationPermissionGranted) {
             finishRequestAndNavigate(receipt);
             return;

--- a/tests/ui/SubmitDetailsPageTest.tsx
+++ b/tests/ui/SubmitDetailsPageTest.tsx
@@ -4,6 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import {act, fireEvent, render, screen} from '@testing-library/react-native';
 
+import Log from '@libs/Log';
+
 import SubmitDetailsPage from '@pages/Share/SubmitDetailsPage';
 
 import CONST from '@src/CONST';
@@ -176,5 +178,59 @@ describe('SubmitDetailsPage', () => {
         expect(typeof requestMoneyArg?.optimisticTransactionID).toBe('string');
         expect(requestMoneyArg?.optimisticTransactionID).not.toBe(CONST.IOU.OPTIMISTIC_TRANSACTION_ID);
         expect(cleanupArg?.transactionID).toBe(requestMoneyArg?.optimisticTransactionID);
+    });
+
+    it('stamps the shared receipt with a trace id and logs the capture and submit milestones with source share', async () => {
+        // Capture each [Receipt] log line into a typed list so assertions never have to cast mock.calls.
+        const receiptLogs: Array<{message: string; params: Record<string, unknown>}> = [];
+        const logInfoSpy = jest.spyOn(Log, 'info').mockImplementation((message, _sendNow, params) => {
+            if (message.includes('[Receipt]') && !!params && typeof params === 'object' && !Array.isArray(params) && !(params instanceof Error)) {
+                receiptLogs.push({message, params});
+            }
+        });
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${SHARED_REPORT_ID}`, createTestReport());
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${CONST.IOU.OPTIMISTIC_TRANSACTION_ID}`, createDraftTransaction());
+            await Onyx.merge(ONYXKEYS.SHARE_TEMP_FILE, {content: 'file://shared.jpg', mimeType: 'image/jpeg'});
+            await Onyx.merge(ONYXKEYS.NVP_LAST_LOCATION_PERMISSION_PROMPT, new Date().toISOString());
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+                [PARTICIPANT_ACCOUNT_ID]: {accountID: PARTICIPANT_ACCOUNT_ID, login: 'participant@example.com', displayName: 'Participant'},
+            });
+        });
+
+        render(
+            <SubmitDetailsPage
+                // @ts-expect-error minimal route for test
+                route={{key: 'submit-test', name: 'Share_Submit_Details', params: {reportOrAccountID: SHARED_REPORT_ID}}}
+                navigation={{} as never}
+            />,
+        );
+
+        await waitForBatchedUpdatesWithAct();
+
+        fireEvent.press(screen.getByTestId('mock-confirm-button'));
+        await waitForBatchedUpdatesWithAct();
+
+        // The trace id minted at capture travels into the request receipt, so the enqueued and snapshot logs can join back to the capture log.
+        const requestMoneyArg = jest.mocked(TrackExpense.requestMoney).mock.calls.at(0)?.[0];
+        const receiptTraceId = requestMoneyArg?.transactionParams?.receipt?.receiptTraceId;
+        expect(typeof receiptTraceId).toBe('string');
+        expect(receiptTraceId).toBeTruthy();
+
+        // The capture milestone fires for the share entry point.
+        const captured = receiptLogs.find((line) => line.params.event === 'captured');
+        expect(captured?.params).toMatchObject({event: 'captured', captureSource: 'share', receiptTraceId});
+
+        // The submit milestone maps the fixed draft id to the final transaction id.
+        const submitted = receiptLogs.find((line) => line.params.event === 'submitted');
+        expect(submitted?.params).toMatchObject({
+            event: 'submitted',
+            receiptTraceId,
+            draftTransactionID: CONST.IOU.OPTIMISTIC_TRANSACTION_ID,
+            transactionID: requestMoneyArg?.optimisticTransactionID,
+        });
+
+        logInfoSpy.mockRestore();
     });
 });


### PR DESCRIPTION
## What

Extends the receipt capture-to-upload telemetry from #94950 to receipts that enter through the iOS Share Extension (print an email, Share, Expensify, Save).

## Why

The trace id was minted in only two places: `buildReceiptFiles.ts` (camera, gallery, file) and `replaceReceipt` in `Receipt.ts`. The share flow goes through neither. It builds the receipt by hand in `SubmitDetailsPage.onSuccess` and calls `requestMoney`/`trackExpense` directly, so it also skips `createTransaction`, where the `submitted` milestone fires.

For a shared receipt this meant:

- No trace id, so we could not follow one receipt from capture to upload.
- The `captured` log never fired, so we lost `mimeType`, `fileExtension`, and `fileSizeBytes`. That is the PDF-format and large-file signal we care about.
- The `submitted` log never fired, so we lost the draft to final `transactionID` mapping.

Only `enqueued` and the queue `snapshot` still fired, both with `receiptTraceId: undefined`, joinable only by `transactionID`. This is the exact variant confirmed lost in production.

## Changes

- Add `'share'` to the `ReceiptCaptureSource` union in `ReceiptObservability.ts`.
- In `SubmitDetailsPage.onSuccess`, stamp the receipt with a trace id and log the capture milestone with `captureSource: 'share'`. The file read from disk carries its type, name, and size, so the capture log gets the format and size fields.
- In `SubmitDetailsPage.finishRequestAndNavigate`, log the submit milestone with the draft and final transaction ids right before the direct `requestMoney`/`trackExpense` call.

The stamp makes `enqueued` and `snapshot` carry a real trace id. The two log calls restore the `captured` and `submitted` milestones, so a shared receipt has the same end-to-end trace as a camera or gallery receipt.

## Tests

Added a test in `SubmitDetailsPageTest.tsx` that drives a share submit and checks the trace id reaches the request receipt, and that the `captured` and `submitted` lines fire with source `share`. The existing `ReceiptObservability` unit tests already cover the shared helpers.

## Related

- Fixes callstack-internal/expensify-issues#2690
- Parent: callstack-internal/expensify-issues#2685
- Builds on #94950
